### PR TITLE
Add text-to-speech functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TextTalk
 
+_Note: Due to use of the `say` terminal command, this application will not work on Windows_
+
 A simple Elixir command line REPL that takes user input and outputs speech.
 
 The program will default to the voice of 'Junior'. A different voice can be specified by separating the text to speak with `|`.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,68 @@
 # TextTalk
 
-A simple Elixir CLI application for converting user-supplied text to speech.
+A simple Elixir command line REPL that takes user input and outputs speech.
 
-<!-- ## Installation
+The program will default to the voice of 'Junior'. A different voice can be specified by separating the text to speak with `|`.
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+Example use of default voice:
+```
+> What would you like me to repeat ('exit' to quit)?
+hello
+```
 
-  1. Add `text_talk` to your list of dependencies in `mix.exs`:
+Example use of specified voice:
+```
+> What would you like me to repeat ('exit' to quit)?
+hello | boing
+```
 
-    ```elixir
-    def deps do
-      [{:text_talk, "~> 0.1.0"}]
-    end
-    ```
+Please see below for a full list of available voices.
 
-  2. Ensure `text_talk` is started before your application:
+The program can be exited at any time with `exit` or `control + C` twice.
 
-    ```elixir
-    def application do
-      [applications: [:text_talk]]
-    end
-    ```
- -->
+## Usage
+
+Clone the application
+```
+$ git clone git@github.com:ryanflach/text_talk.git
+```
+`cd` into the directory and compile
+```
+$ cd text_talk
+$ mix compile
+```
+Launch the application
+```
+$ mix run
+```
+
+### Available voices
+Female Voices
+- Agnes
+- Kathy
+- Princess
+- Vicki
+- Victoria
+
+Male Voices
+- Alex
+- Bruce
+- Fred
+- Junior
+- Ralph
+
+Novelty Voices
+- Albert
+- Bad News
+- Bahh
+- Bells
+- Boing
+- Bubbles
+- Cellos
+- Deranged
+- Good News
+- Hysterical
+- Pipe Organ
+- Trinoids
+- Whisper
+- Zarvox

--- a/lib/text_talk.ex
+++ b/lib/text_talk.ex
@@ -1,2 +1,10 @@
 defmodule TextTalk do
+  use Application
+
+  def start(_type, _args) do
+    IO.puts "* * * * * * * * *"
+    IO.puts "* W E L C O M E *"
+    IO.puts "* * * * * * * * *\n"
+    TextTalk.Speech.get_input
+  end
 end

--- a/lib/text_talk/speech.ex
+++ b/lib/text_talk/speech.ex
@@ -1,0 +1,45 @@
+defmodule TextTalk.Speech do
+  @doc """
+  Takes an input from the user and sends to process. An input without
+  a second argument specified (via `|`) will use the default voice of
+  Junior when spoken through private method `speak/2`. An input of
+  `exit` (case insensitive) will exit the program.
+  """
+  def get_input do
+    IO.puts "Note: To specify a voice, pass it as a second argument after '|'"
+    IO.puts "For example, 'hello | Boing' would say hello in the Boing voice.\n\n"
+    line = IO.gets "What would you like me to repeat ('exit' to quit)?\n"
+    process_input(line)
+  end
+
+  defp process_input(input) do
+    line = String.split(input, "|")
+           |> Enum.map(fn(x) -> String.trim(x) end)
+
+    if String.downcase(hd(line)) == "exit" do
+      exit_program
+    end
+
+    send_to_speech(line)
+  end
+
+  defp send_to_speech(line) when length(line) < 2 do
+    speak(hd(line))
+    get_input
+  end
+
+  defp send_to_speech(line) do
+    speak(hd(line), tl(line))
+    get_input
+  end
+
+  defp speak(line, voice \\ "Junior") do
+    System.cmd "say", ["-v#{voice}", line]
+    {:ok, voice, line}
+  end
+
+  defp exit_program do
+    IO.puts "Goodbye!"
+    System.halt(0)
+  end
+end

--- a/lib/text_talk/speech.ex
+++ b/lib/text_talk/speech.ex
@@ -8,30 +8,24 @@ defmodule TextTalk.Speech do
   def get_input do
     IO.puts "Note: To specify a voice, pass it as a second argument after '|'"
     IO.puts "For example, 'hello | Boing' would say hello in the Boing voice.\n\n"
-    line = IO.gets "What would you like me to repeat ('exit' to quit)?\n"
-    process_input(line)
+    IO.gets("What would you like me to say ('exit' to quit)?\n")
+      |> process_input
+    get_input
   end
 
   defp process_input(input) do
-    line = String.split(input, "|")
-           |> Enum.map(fn(x) -> String.trim(x) end)
-
-    if String.downcase(hd(line)) == "exit" do
-      exit_program
-    end
-
-    send_to_speech(line)
+    input
+      |> String.downcase
+      |> String.split("|")
+      |> Enum.map(&String.trim/1)
+      |> send_to_speech
   end
 
-  defp send_to_speech(line) when length(line) < 2 do
-    speak(hd(line))
-    get_input
-  end
+  defp send_to_speech(["exit" | _]), do: exit_program
 
-  defp send_to_speech(line) do
-    speak(hd(line), tl(line))
-    get_input
-  end
+  defp send_to_speech([text]), do: speak(text)
+
+  defp send_to_speech([text, voice | _]), do: speak(text, voice)
 
   defp speak(line, voice \\ "Junior") do
     System.cmd "say", ["-v#{voice}", line]

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule TextTalk.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger],
+     mod: {TextTalk, []}]
   end
 
   # Dependencies can be Hex packages:

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,0 @@
-ExUnit.start()

--- a/test/text_talk_test.exs
+++ b/test/text_talk_test.exs
@@ -1,8 +1,0 @@
-defmodule TextTalkTest do
-  use ExUnit.Case
-  doctest TextTalk
-
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
-end


### PR DESCRIPTION
This PR completes base functionality of the CLI accepting input from the user and converting to speech. Additionally, documentation has been updated and completed.

Notes by file:
- `lib/text_talk.ex`
  - `start/2` is run automatically with `mix run`
  - Triggers output of a welcome message and runs the `get_input/0` function in the Speech module.
- `lib/text_talk/speech.ex`
  - Main functionality lives here
  - documentation is discarded for private methods, so it is only supplied for `get_input/0`
  - `process_input/1` splits the input string at '|' and sends to exit if the head of the created List is 'exit' - matching case insensitively. Otherwise the split input is sent to one of two functions.
  - `send_to_speech/1` has two variants - one with a clause for when there is only a head in the List, and one that processes a list with two items. Both send the appropriate args to `speak/2`
  - `speak/2` accepts two args and has a default for the second (voice). This function triggers the actual speech. It returns a tuple of `{:ok, line, voice}`, though this would only been seen in iex.
  - `exit_program/0` outputs a message and exits the program.

In `exit_program/0` I am using `System.halt(0)` to exit discretely (i.e., without warning output). I was originally attempting to use `exit/1` but was unable to find a means of doing so discretely. Because of the simplicity of this program (no other running processes) `System.halt(0)` seems fine, but I would love to know of a better way, if there is something more appropriate in this context.